### PR TITLE
Allow float for -w and -c.

### DIFF
--- a/check_es_insert.py
+++ b/check_es_insert.py
@@ -130,8 +130,8 @@ class Elasticsearcher():
 def getArgs(helptext):
     '''Here's where we get our command line arguments'''
     parser = argparse.ArgumentParser(description=helptext)
-    parser.add_argument('-c','--critical', type=int, help='Critical value', action='store',required=True)
-    parser.add_argument('-w','--warning', type=int, help='Warning value', action='store',required=True)
+    parser.add_argument('-c','--critical', type=float, help='Critical value', action='store',required=True)
+    parser.add_argument('-w','--warning', type=float, help='Warning value', action='store',required=True)
     parser.add_argument('-t','--threshold', choices=['lt','gt'], type=str, help='Check result less than (lt) or greater than (gt) the warning/critcal values', action='store',default='lt')
     parser.add_argument('-a','--address', type=str, help='Elasticsearch address', action='store',default='localhost:9200')
     parser.add_argument('-i','--index', type=str, help='Elasticsearch index', action='store',default='')


### PR DESCRIPTION
I'm using check-es to make sure logstash is publishing to and index.  Even though the rate is generally above 1 Hz, this is not necessarily always the case, so I'd prefer to use something more like -w .00167 -c .000278.
